### PR TITLE
fix(FEV-1208): WHY (explanation) is not displayed on the player

### DIFF
--- a/src/components/quiz-review/question-review/question-review.tsx
+++ b/src/components/quiz-review/question-review/question-review.tsx
@@ -110,6 +110,7 @@ export const QuestionReview = withText(translates)(
         return (
           <Fragment>
             <div className={styles.openQuestionAnswer}>{a?.openAnswer}</div>
+            {q.explanation && <QuestionAddons explanation={q.explanation} />}
             {a?.feedback && <QuestionAddons feedback={a?.feedback} />}
           </Fragment>
         );


### PR DESCRIPTION
added 'why' to open question review