### PR TITLE
fix(FEV-1279): scrubber doesn't show the location of the questions in the timeline after media switch

### DIFF
--- a/src/ivq.tsx
+++ b/src/ivq.tsx
@@ -35,7 +35,7 @@ export class Ivq extends KalturaPlayer.core.BasePlugin {
     this._quizDataPromise = this._makeQuizDataPromise();
     this._quizQuestionsPromise = this._makeQuizQuestionsPromise();
     this._dataManager = new DataSyncManager(
-      this._resolveQuizQuestionsPromise,
+      (qqm: QuizQuestionMap) => this._resolveQuizQuestionsPromise(qqm),
       (qq: KalturaQuizQuestion) => this._questionsVisualManager.onQuestionCuepointActive(qq),
       this._seekControl,
       this.eventManager,


### PR DESCRIPTION
 resolve new resolve quiz ready promise after reset