### PR TITLE
fix(FEV-1243): A11y - Timeline questions are not readable

### DIFF
--- a/src/components/timeline/timeline-marker.tsx
+++ b/src/components/timeline/timeline-marker.tsx
@@ -1,5 +1,5 @@
 import {h} from 'preact';
-import {useMemo} from 'preact/hooks';
+import {useMemo, useCallback} from 'preact/hooks';
 import * as styles from './timeline-marker.scss';
 import {QuizTranslates, TimelineMarkerProps} from '../../types';
 import {A11yWrapper} from '../a11y-wrapper';
@@ -22,14 +22,23 @@ const translates = ({questionIndex}: TimelineMarkerProps): QuizTranslates => {
   };
 };
 
-export const TimelineMarker = withText(translates)(({isDisabled, onClick, ...otherProps}: TimelineMarkerProps & QuizTranslates) => {
+export const TimelineMarker = withText(translates)(({isDisabled, onClick, getSeekBarNode, ...otherProps}: TimelineMarkerProps & QuizTranslates) => {
   const hoverActive = useSelector((state: any) => state.seekbar.hoverActive);
   useSelector((state: any) => state.seekbar); // trigger update of marker component
+  const handleFocus = useCallback(() => {
+    const seekBarNode = getSeekBarNode();
+    if (seekBarNode) {
+      // change slider valuetext attribute to force screen-reader read question marker
+      // once playback continue - valuetext changed by seekbar component to playback-time value
+      seekBarNode.setAttribute('aria-valuetext', otherProps.markerAriaLabel as string);
+    }
+  }, []);
   const disabled = isDisabled();
   const renderMarker = useMemo(() => {
     return (
       <A11yWrapper onClick={onClick}>
         <div
+          onFocus={handleFocus}
           role="button"
           title={otherProps.markerAriaLabel as string}
           tabIndex={disabled ? -1 : 0}

--- a/src/ivq.tsx
+++ b/src/ivq.tsx
@@ -150,6 +150,7 @@ export class Ivq extends KalturaPlayer.core.BasePlugin {
               return (
                 <TimelineMarker
                   {...props}
+                  getSeekBarNode={this._getSeekBarNode}
                   onClick={handleOnQuestionClick}
                   questionIndex={qq.index}
                   isDisabled={() => {

--- a/src/types/quizTypesUI.ts
+++ b/src/types/quizTypesUI.ts
@@ -54,6 +54,7 @@ export interface TimelineMarkerProps {
   style: Record<string, any>;
   onClick: (e: Event) => void;
   isDisabled: () => boolean;
+  getSeekBarNode: () => Element | null;
   questionIndex: number;
 }
 


### PR DESCRIPTION
according to W3 documentation - Screen readers ignores Presentational children (https://www.w3.org/TR/wai-aria-1.1/#childrenArePresentational). To force Screen readers read ivq timeline-markers slider component receive new aria-valuetext value.