### PR TITLE
fix(FEV-1247): Safari| Continue button is not accessible

### DIFF
--- a/src/components/ivq-bottom-bar/ivq-bottom-bar.tsx
+++ b/src/components/ivq-bottom-bar/ivq-bottom-bar.tsx
@@ -1,5 +1,6 @@
 import {h, VNode} from 'preact';
 import {useMemo, useEffect, useRef} from 'preact/hooks';
+import {A11yWrapper, OnClick} from '@playkit-js/common';
 import {icons} from '../icons';
 import {QuizTranslates} from '../../types';
 import * as styles from './ivq-bottom-bar.scss';
@@ -8,8 +9,8 @@ const {Icon} = KalturaPlayer.ui.components;
 const {withText, Text} = KalturaPlayer.ui.preacti18n;
 
 interface IvqBottomBarProps {
-  onPrev?: () => void;
-  onNext?: () => void;
+  onPrev?: OnClick;
+  onNext?: OnClick;
   questionCounter: string | VNode<{}>;
   getSeekBarNode: () => Element | null;
 }
@@ -33,21 +34,27 @@ export const IvqBottomBar = withText(translates)(
     const renderIvqNavigation = useMemo(() => {
       return (
         <div className={styles.ivqNavigationWrapper}>
-          <button
-            disabled={!onPrev}
-            onClick={onPrev}
-            className={[styles.navigationButton, !onPrev ? styles.disabled : ''].join(' ')}
-            aria-label={otherProps.prevQuestionButtonAriaLabel}>
-            <Icon id="ivq-chevron-left" height={14} width={9} viewBox={`0 0 ${icons.SmallSize} ${icons.SmallSize}`} path={icons.CHEVRON_LEFT} />
-          </button>
+          <A11yWrapper onClick={onPrev ? onPrev : () => {}}>
+            <div
+              role="button"
+              tabIndex={0}
+              disabled={!onPrev}
+              className={[styles.navigationButton, !onPrev ? styles.disabled : ''].join(' ')}
+              aria-label={otherProps.prevQuestionButtonAriaLabel}>
+              <Icon id="ivq-chevron-left" height={14} width={9} viewBox={`0 0 ${icons.SmallSize} ${icons.SmallSize}`} path={icons.CHEVRON_LEFT} />
+            </div>
+          </A11yWrapper>
           <div className={styles.questionIndex}>{questionCounter}</div>
-          <button
-            disabled={!onNext}
-            onClick={onNext}
-            className={[styles.navigationButton, !onNext ? styles.disabled : ''].join(' ')}
-            aria-label={otherProps.nextQuestionButtonAriaLabel}>
-            <Icon id="ivq-chevron-right" height={14} width={9} viewBox={`0 0 ${icons.SmallSize} ${icons.SmallSize}`} path={icons.CHEVRON_RIGHT} />
-          </button>
+          <A11yWrapper onClick={onNext ? onNext : () => {}}>
+            <div
+              role="button"
+              tabIndex={0}
+              disabled={!onNext}
+              className={[styles.navigationButton, !onNext ? styles.disabled : ''].join(' ')}
+              aria-label={otherProps.nextQuestionButtonAriaLabel}>
+              <Icon id="ivq-chevron-right" height={14} width={9} viewBox={`0 0 ${icons.SmallSize} ${icons.SmallSize}`} path={icons.CHEVRON_RIGHT} />
+            </div>
+          </A11yWrapper>
         </div>
       );
     }, [onNext, onPrev, questionCounter]);

--- a/src/components/quiz-question/quiz-question-wrapper.tsx
+++ b/src/components/quiz-question/quiz-question-wrapper.tsx
@@ -54,7 +54,7 @@ export const QuizQuestionWrapper = withText(translates)((props: QuizQuestionWrap
   const {qui, getSeekBarNode} = props;
   const [selected, setSelected] = useState<Selected>(getSelected(qui));
   const [isLoading, setIsLoading] = useState(false);
-  const continueButtonRef = useRef<HTMLButtonElement>(null);
+  const continueButtonRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     // wait till plugin gets player store
@@ -148,25 +148,30 @@ export const QuizQuestionWrapper = withText(translates)((props: QuizQuestionWrap
     return (
       <div className={styles.ivqButtonsWrapper}>
         <A11yWrapper onClick={handleContinue}>
-          <button
+          <div
+            role="button"
+            tabIndex={0}
             ref={continueButtonRef}
             data-testid="continueButton"
             disabled={continueDisabled}
             aria-label={continueButtonAriaLabel}
             className={[styles.continueButton, continueDisabled ? styles.disabled : ''].join(' ')}>
             {isLoading ? <Spinner /> : props.continueButton}
-          </button>
+          </div>
         </A11yWrapper>
 
         {qui.onSkip && (
-          <button
-            data-testid="skipButton"
-            onClick={handleSkip}
-            aria-label={props.skipButtonAriaLabel}
-            className={[styles.skipButton, isLoading ? styles.disabled : ''].join(' ')}
-            disabled={isLoading}>
-            {props.skipButton}
-          </button>
+          <A11yWrapper onClick={handleSkip}>
+            <div
+              role="button"
+              tabIndex={0}
+              data-testid="skipButton"
+              aria-label={props.skipButtonAriaLabel}
+              className={[styles.skipButton, isLoading ? styles.disabled : ''].join(' ')}
+              disabled={isLoading}>
+              {props.skipButton}
+            </div>
+          </A11yWrapper>
         )}
       </div>
     );

--- a/src/components/quiz-review/question-list-review/question-list-review.tsx
+++ b/src/components/quiz-review/question-list-review/question-list-review.tsx
@@ -104,22 +104,28 @@ export const QuestionListReview = withText(translates)(
         <div className={styles.questionsWrapper}>{showAnswers && renderAnswers}</div>
         <div className={styles.buttonWrapper} data-testid="reviewButtonWrapper">
           {onRetake && (
-            <button
-              onClick={handleRetake}
-              className={styles.primaryButton}
-              aria-label={otherProps.retakeButtonAreaLabel}
-              data-testid="reviewRetakeButton"
-              disabled={isLoading}>
-              {isLoading ? <Spinner /> : otherProps.retakeButton}
-            </button>
+            <A11yWrapper onClick={handleRetake}>
+              <div
+                role="button"
+                tabIndex={0}
+                className={styles.primaryButton}
+                aria-label={otherProps.retakeButtonAreaLabel}
+                data-testid="reviewRetakeButton"
+                disabled={isLoading}>
+                {isLoading ? <Spinner /> : otherProps.retakeButton}
+              </div>
+            </A11yWrapper>
           )}
-          <button
-            onClick={onClose}
-            data-testid="reviewDoneButton"
-            className={[onRetake ? styles.secondaryButton : styles.primaryButton, isLoading ? styles.disabled : ''].join(' ')}
-            aria-label={otherProps.doneButtonAreaLabel}>
-            {otherProps.doneButton}
-          </button>
+          <A11yWrapper onClick={onClose}>
+            <div
+              role="button"
+              tabIndex={0}
+              data-testid="reviewDoneButton"
+              className={[onRetake ? styles.secondaryButton : styles.primaryButton, isLoading ? styles.disabled : ''].join(' ')}
+              aria-label={otherProps.doneButtonAreaLabel}>
+              {otherProps.doneButton}
+            </div>
+          </A11yWrapper>
         </div>
       </div>
     );

--- a/src/components/quiz-review/question-review/question-review.tsx
+++ b/src/components/quiz-review/question-review/question-review.tsx
@@ -1,5 +1,6 @@
 import {h, Fragment} from 'preact';
 import {useMemo, useRef, useEffect} from 'preact/hooks';
+import {A11yWrapper} from '@playkit-js/common';
 import {QuizTranslates, QuizQuestion, KalturaQuizQuestionTypes} from '../../../types';
 import {makeQuestionLabels} from '../../../utils';
 import {icons} from '../../icons';
@@ -47,7 +48,7 @@ const translates = ({questionsAmount, reviewQuestion}: QuestionReviewProps): Qui
 
 export const QuestionReview = withText(translates)(
   ({onBack, onNext, onPrev, questionCounter, reviewQuestion, getSeekBarNode, ...otherProps}: QuestionReviewProps & QuizTranslates) => {
-    const backButtonRef = useRef<HTMLButtonElement>(null);
+    const backButtonRef = useRef<HTMLDivElement>(null);
     const {q, a} = reviewQuestion.qq;
 
     useEffect(() => {
@@ -149,12 +150,14 @@ export const QuestionReview = withText(translates)(
       <Fragment>
         <div className={['ivq', styles.questionReviewWrapper].join(' ')} role="dialog" aria-live="polite">
           <div className={styles.backButtonContainer}>
-            <button onClick={onBack} className={styles.backButton} ref={backButtonRef}>
-              <div className={styles.iconContainer} aria-hidden="true">
-                <Icon id="ivq-chevron-left" height={14} width={9} viewBox={`0 0 ${icons.SmallSize} ${icons.SmallSize}`} path={icons.CHEVRON_LEFT} />
+            <A11yWrapper onClick={onBack}>
+              <div role="button" tabIndex={0} className={styles.backButton} ref={backButtonRef}>
+                <div className={styles.iconContainer} aria-hidden="true">
+                  <Icon id="ivq-chevron-left" height={14} width={9} viewBox={`0 0 ${icons.SmallSize} ${icons.SmallSize}`} path={icons.CHEVRON_LEFT} />
+                </div>
+                {otherProps.backButton}
               </div>
-              {otherProps.backButton}
-            </button>
+            </A11yWrapper>
           </div>
           <div className={styles.quizQuestionContainer}>
             <legend className={styles.questionText}>

--- a/src/components/quiz-submit/quiz-submit.tsx
+++ b/src/components/quiz-submit/quiz-submit.tsx
@@ -1,5 +1,6 @@
 import {h} from 'preact';
 import {useCallback, useState, useRef, useEffect} from 'preact/hooks';
+import {A11yWrapper} from '@playkit-js/common';
 import {QuizTranslates} from '../../types';
 import {IvqOverlay} from '../ivq-overlay';
 import {Spinner} from '../spinner';
@@ -33,8 +34,8 @@ const translates = ({onSubmit}: QuizSubmitProps): QuizTranslates => {
 
 export const QuizSubmit = withText(translates)(({onReview, onSubmit, ...otherProps}: QuizSubmitProps & QuizTranslates) => {
   const [isLoading, setIsLoading] = useState(false);
-  const submitButtonRef = useRef<HTMLButtonElement>(null);
-  const reviewButtonRef = useRef<HTMLButtonElement>(null);
+  const submitButtonRef = useRef<HTMLDivElement>(null);
+  const reviewButtonRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     const playerNav = useSelector((state: any) => state.shell.playerNav);
     if (!playerNav) {
@@ -66,23 +67,29 @@ export const QuizSubmit = withText(translates)(({onReview, onSubmit, ...otherPro
         </div>
         <div className={styles.buttonWrapper} data-testid="submitButton">
           {onSubmit && (
-            <button
-              onClick={handleSubmitClick}
-              className={styles.primaryButton}
-              aria-label={otherProps.submitButtonAriaLabel}
-              disabled={isLoading}
-              ref={submitButtonRef}>
-              {isLoading ? <Spinner /> : otherProps.submitButton}
-            </button>
+            <A11yWrapper onClick={handleSubmitClick}>
+              <div
+                role="button"
+                tabIndex={0}
+                className={styles.primaryButton}
+                aria-label={otherProps.submitButtonAriaLabel}
+                disabled={isLoading}
+                ref={submitButtonRef}>
+                {isLoading ? <Spinner /> : otherProps.submitButton}
+              </div>
+            </A11yWrapper>
           )}
-          <button
-            onClick={handleReviewClick}
-            disabled={isLoading}
-            className={[onSubmit ? styles.secondaryButton : styles.primaryButton, isLoading ? styles.disabled : ''].join(' ')}
-            aria-label={otherProps.reviewButtonAriaLabel}
-            ref={reviewButtonRef}>
-            {otherProps.reviewButton}
-          </button>
+          <A11yWrapper onClick={handleReviewClick}>
+            <div
+              role="button"
+              tabIndex={0}
+              disabled={isLoading}
+              className={[onSubmit ? styles.secondaryButton : styles.primaryButton, isLoading ? styles.disabled : ''].join(' ')}
+              aria-label={otherProps.reviewButtonAriaLabel}
+              ref={reviewButtonRef}>
+              {otherProps.reviewButton}
+            </div>
+          </A11yWrapper>
         </div>
       </div>
     </IvqOverlay>

--- a/src/components/welcome-screen/welcome-screen.tsx
+++ b/src/components/welcome-screen/welcome-screen.tsx
@@ -53,9 +53,9 @@ export const WelcomeScreen = withText(translates)(
             <div className={styles.buttonWrapper}>
               {onClose && (
                 <A11yWrapper onClick={onClose}>
-                  <button data-testid="startQuiz" aria-label={otherProps.startQuiz} className={styles.startQuizButton}>
+                  <div role="button" data-testid="startQuiz" aria-label={otherProps.startQuiz} className={styles.startQuizButton} tabIndex={0}>
                     {otherProps.startQuiz}
-                  </button>
+                  </div>
                 </A11yWrapper>
               )}
               {onDownload && (


### PR DESCRIPTION
Safari has issue with focus on `<button>` elements, changed `<button>` to `<div>` + added a11y wrapper