### PR TITLE
fix(FEV-1607): on chrome browser only, there is a scroll bar inside the quiz questions

### DIFF
--- a/src/components/ivq-overlay/ivq-overlay.scss
+++ b/src/components/ivq-overlay/ivq-overlay.scss
@@ -9,6 +9,7 @@
     display: flex;
     flex-direction: column;
     padding: 0 !important; // overwrite responsive overlay styles
+    overflow: hidden;
   }
 }
 


### PR DESCRIPTION
**the issue:**
on chrome browser, when ivq overlay is displayed, a scrollbar appears on the side.

**solution:**
add `overflow: hidden` to override core's css.

Solves [FEV-1607](https://kaltura.atlassian.net/browse/FEV-1607)