### PR TITLE
fix(FEV-1603): when navigating to an answer option, screen reader guides to use the arrow keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,6 @@
     }
   },
   "dependencies": {
-    "@playkit-js/common": "^1.0.7"
+    "@playkit-js/common": "^1.0.16"
   }
 }

--- a/src/components/quiz-question/multi-choice/multi-choice.tsx
+++ b/src/components/quiz-question/multi-choice/multi-choice.tsx
@@ -36,12 +36,19 @@ export const MultiChoice = withText(translates)(
     const selectedArray = selected ? selected.split(',') : [];
     const disabled = !onSelect;
     const quizQuestionRef = useRef<HTMLLegendElement>(null);
+    let answersOptionsRefMap: Map<number, HTMLElement | null> = new Map();
 
     useEffect(() => {
       if (!disabled) {
         quizQuestionRef.current?.focus();
       }
     }, [question]);
+
+    useEffect(() => {
+        return () => {
+            answersOptionsRefMap = new Map();
+        }
+    }, []);
 
     const handleSelect = useCallback(
       (key: string, isActive: boolean) => (e: Event, byKeyboard?: boolean) => {
@@ -58,6 +65,22 @@ export const MultiChoice = withText(translates)(
       [onSelect, selectedArray]
     );
 
+    const setAnswerOptionRef = (index: number, ref: HTMLElement | null) => {
+        return answersOptionsRefMap.set(index, ref);
+    };
+
+    const getAnswerOptionRef = (index: number) => {
+        return answersOptionsRefMap.get(index);
+    };
+
+    const handleUpKeyPressed = (currentIndex: number) => {
+        getAnswerOptionRef(currentIndex - 1)?.focus();
+    };
+
+    const handleDownKeyPressed = (currentIndex: number) => {
+        getAnswerOptionRef(currentIndex + 1)?.focus();
+    };
+
     return (
       <div className={styles.multiChoiceWrapper} data-testid="multipleChoiceContainer">
         <legend className={styles.questionText} data-testid="multipleChoiceQuestionTitle" tabIndex={0} role="text" ref={quizQuestionRef}>
@@ -70,8 +93,15 @@ export const MultiChoice = withText(translates)(
             {optionalAnswers.map(({key, text}, index) => {
               const isActive = selectedArray.includes(key);
               return (
-                <A11yWrapper onClick={handleSelect(key, isActive)}>
+                <A11yWrapper
+                    onClick={handleSelect(key, isActive)}
+                    onUpKeyPressed={() => handleUpKeyPressed(index)}
+                    onDownKeyPressed={() => handleDownKeyPressed(index)}
+                >
                   <div
+                    ref={node => {
+                        setAnswerOptionRef(index, node);
+                    }}
                     key={key}
                     role="option"
                     tabIndex={0}

--- a/src/components/quiz-question/true-false/true-false.tsx
+++ b/src/components/quiz-question/true-false/true-false.tsx
@@ -31,6 +31,29 @@ export const TrueFalse = withText(translates)(
       }
     }, [question]);
 
+    let answersOptionsRefMap: Map<number, HTMLElement | null> = new Map();
+    useEffect(() => {
+        return () => {
+            answersOptionsRefMap = new Map();
+        }
+    }, []);
+
+      const setAnswerOptionRef = (index: number, ref: HTMLElement | null) => {
+          return answersOptionsRefMap.set(index, ref);
+      };
+
+      const getAnswerOptionRef = (index: number) => {
+          return answersOptionsRefMap.get(index);
+      };
+
+      const handleLeftKeyPressed = (currentIndex: number) => {
+          getAnswerOptionRef(currentIndex - 1)?.focus();
+      };
+
+      const handleRightKeyPressed = (currentIndex: number) => {
+          getAnswerOptionRef(currentIndex + 1)?.focus();
+      };
+
     return (
       <div className={styles.trueFalseWrapper} data-testid="trueFalseContainer">
         <legend className={styles.questionText} data-testid="trueFalseQuestionTitle" tabIndex={0} role="text" ref={quizQuestionRef}>
@@ -43,8 +66,17 @@ export const TrueFalse = withText(translates)(
             const isActive = selected.includes(key);
             const classes = [styles.trueFalseAnswer, isActive ? styles.active : '', disabled ? styles.disabled : ''].join(' ');
             return (
-              <A11yWrapper onClick={handleSelect(key)}>
+              <A11yWrapper
+                  onClick={handleSelect(key)}
+                  onUpKeyPressed={() => {}}
+                  onDownKeyPressed={() => {}}
+                  onLeftKeyPressed={() => handleLeftKeyPressed(index)}
+                  onRightKeyPressed={() => handleRightKeyPressed(index)}
+              >
                 <div
+                  ref={node => {
+                      setAnswerOptionRef(index, node);
+                  }}
                   key={key}
                   tabIndex={0}
                   data-testid="trueFalseAnswerContent"

--- a/yarn.lock
+++ b/yarn.lock
@@ -554,10 +554,10 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.3.tgz#0300943770e04231041a51bd39f0439b5c7ab4f0"
   integrity sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg==
 
-"@playkit-js/common@^1.0.7":
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/@playkit-js/common/-/common-1.0.7.tgz#ef4505c08584fde300638892add98f856691d778"
-  integrity sha512-6rr+k5c6y7aITG1NRH3PnYSm1l20Id905NMp8XQbA4DmJk0r4AX5sz9YfH9NSGDQx3UKYGkLLYSEbwFYlfFu+g==
+"@playkit-js/common@^1.0.16":
+  version "1.0.16"
+  resolved "https://registry.yarnpkg.com/@playkit-js/common/-/common-1.0.16.tgz#cee57df0909bcbc1ab85e97b222ce93d05c1104a"
+  integrity sha512-40QWemEF8QQd23kpFsU20WycVt9A8oRN1wQPq66ORaKMtgXANkTk6V83UNlifa9eNw6K9ovugRnHd9mxCE6Y2w==
   dependencies:
     linkify-it "^4.0.1"
 


### PR DESCRIPTION
**the issue:**
when navigating using tab keyboard to an answer option, screen reader Jaws guides to use the arrow keys to navigate between the answers options.

**solution:**
- update common repo
- use up/down keyboard handlers for multiple choices questions
- use new left/right keyboard handlers for true/false questions

Solves [FEV-1603](https://kaltura.atlassian.net/browse/FEV-1603)