### PR TITLE
feat(FEC-13057): add Quiz to navigation

### DIFF
--- a/src/types/ivqEventTypes.ts
+++ b/src/types/ivqEventTypes.ts
@@ -2,5 +2,6 @@ export enum IvqEventTypes {
   QUIZ_STARTED = 'QuizStarted',
   QUESTION_ANSWERED = 'QuestionAnswered',
   QUIZ_SUBMITTED = 'QuizSubmitted',
-  QUIZ_RETAKE = 'QuizRetake'
+  QUIZ_RETAKE = 'QuizRetake',
+  QUIZ_QUESTION_CHANGED = 'QuizQuestionChanged'
 }

--- a/src/types/questionStateTypes.ts
+++ b/src/types/questionStateTypes.ts
@@ -1,0 +1,6 @@
+export enum QuestionStateTypes {
+  UNANSWERED = 1,
+  ANSWERED = 2,
+  INCORRECT = 3,
+  CORRECT = 4
+}


### PR DESCRIPTION
**Changes:**
- dispatch new event called "QuizQuestionChanged", for any changes in quizQuestionsMap and after clicking on continue button, which its payload incudes relevant data for navigation
- handle `showCorrectAfterSubmission` configuration - do not pass `correct` and `incorrect` states
- handle `preventSeek` configuration - in case this configuration is enabled we want to send in payload only relevant cuepoints and not all of them.