### PR TITLE
fix(SUP-38205):Youtube IVQ missing welcome screen

### DIFF
--- a/src/components/welcome-screen/welcome-screen.scss
+++ b/src/components/welcome-screen/welcome-screen.scss
@@ -7,6 +7,7 @@
   width: 100%;
   height: 100%;
   text-align: left;
+  z-index: 1;
 
   &.withPoster {
     background-size: contain;


### PR DESCRIPTION
issue:
on youtube video with quiz the welcome screen didnt display

solution:
add z-index for welcome screen and update z-index for play button so the welcome screen will be show on top on the video