### PR TITLE
feat(FEC-13313): wrap IvqOverlay with OverlayPortal

### DIFF
--- a/src/components/ivq-overlay/ivq-overlay.scss
+++ b/src/components/ivq-overlay/ivq-overlay.scss
@@ -9,6 +9,8 @@
   position: absolute;
   width: 100%;
   height: 100%;
+  top: 0;
+  left: 0;
   > :global(.playkit-overlay .playkit-overlay-contents) {
     display: flex;
     flex-direction: column;

--- a/src/components/ivq-overlay/ivq-overlay.scss
+++ b/src/components/ivq-overlay/ivq-overlay.scss
@@ -5,6 +5,10 @@
 }
 
 .ivqOverlay {
+  z-index: 1;
+  position: absolute;
+  width: 100%;
+  height: 100%;
   > :global(.playkit-overlay .playkit-overlay-contents) {
     display: flex;
     flex-direction: column;

--- a/src/components/ivq-overlay/ivq-overlay.tsx
+++ b/src/components/ivq-overlay/ivq-overlay.tsx
@@ -1,5 +1,6 @@
 import {h, VNode} from 'preact';
 import * as styles from './ivq-overlay.scss';
+import {OverlayPortal} from '@playkit-js/common/dist/hoc/overlay-portal';
 
 const {Overlay} = KalturaPlayer.ui.components;
 
@@ -9,10 +10,12 @@ interface IvqOverlayProps {
 
 export const IvqOverlay = ({children}: IvqOverlayProps) => {
   return (
-    <div className={styles.ivqOverlay} aria-live="polite">
-      <Overlay open permanent>
-        {children}
-      </Overlay>
-    </div>
+    <OverlayPortal>
+      <div className={styles.ivqOverlay} aria-live="polite">
+        <Overlay open permanent>
+          {children}
+        </Overlay>
+      </div>
+    </OverlayPortal>
   );
 };


### PR DESCRIPTION
when injecting a Slate component, which is being injected inside OverlayPortal area, it is being overlayed with ivq overlay.
slate component should be on top of it. Hence, wrapping `IvqOverlay` component with `OverlayPortal` to place it inside the overlay portal area.

Part of [FEC-13313](https://kaltura.atlassian.net/browse/FEC-13313)

[FEC-13313]: https://kaltura.atlassian.net/browse/FEC-13313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ