### PR TITLE
fix(SUP-39123): Video Quiz Allowing Quiz Seeking

### DIFF
--- a/src/ivq.tsx
+++ b/src/ivq.tsx
@@ -138,7 +138,10 @@ export class Ivq extends KalturaPlayer.core.BasePlugin {
   private _makeOnClickHandler = (id: string) => () => {
     const quizQuestion = this._dataManager.quizQuestionsMap.get(id);
     if (quizQuestion) {
-      this._questionsVisualManager.preparePlayer(quizQuestion, true);
+      const {startTime} = quizQuestion;
+      if (!this._shouldPreventSeek(startTime)){
+        this._questionsVisualManager.preparePlayer(quizQuestion, true);
+      }
     }
   };
 


### PR DESCRIPTION
**issue:**
jump to question is allowed by clicking on the marker even if the "No seeking forward" is enabled

**solution:**
when clicking on marker, check if we should prevent the seeking.

solves [SUP-39123](https://kaltura.atlassian.net/browse/SUP-39123)