### PR TITLE
fix(FEC-13781): add validation to new isPreventSeek state

### DIFF
--- a/src/data-sync-manager.ts
+++ b/src/data-sync-manager.ts
@@ -67,7 +67,7 @@ export class DataSyncManager {
       this._logger.warn('initDataManager: quizData or quizUserEntry absent');
       return;
     }
-    if (this.quizData.preventSeek && !allowSeek) {
+    if ((this.quizData.preventSeek && !allowSeek) || this._player.ui.store.getState().seekbar.isPreventSeek) {
       this._enableSeekControl();
     }
     this._syncEvents();


### PR DESCRIPTION
**the issue:**
When `PreventFwdSeek` set to `true`, "Quiz completed" toast is displayed although not all of the question were answered.

**solution:**
use new redux state isPreventSeek to enable seek control in ivq.

**dependent on PR:** https://github.com/kaltura/playkit-js-ui/pull/867

Solves [FEC-13781](https://kaltura.atlassian.net/browse/FEC-13781)

[FEC-13781]: https://kaltura.atlassian.net/browse/FEC-13781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ