### PR TITLE
fix(FEC-141472): pass new prop to overlay

### DIFF
--- a/src/components/welcome-screen/welcome-screen.tsx
+++ b/src/components/welcome-screen/welcome-screen.tsx
@@ -121,6 +121,7 @@ export const WelcomeScreen = withText(translates)(
       ),
       []
     );
-    return onClose ? <Overlay open permanent children={renderWelcomeScreen} /> : renderWelcomeScreen;
+    // TODO: check why Overlay component is not being rendered under OverlayPortal component
+    return onClose ? <Overlay open permanent children={renderWelcomeScreen} dontCheckOverlayPortal /> : renderWelcomeScreen;
   }
 );


### PR DESCRIPTION
pass new prop to `Overlay` component in `welcomeScreen` component - `dontCheckOverlayPortal`, which tells `Overlay` component to not check `overlayPortal` when removing `overlay-active` class, since it is being rendered outside of overlayPortal area.

**NOTE:** left a TODO note to check why the `Overlay` is not being rendered under `OverlayPortal`, as we usually do.

Resolves [FEC-14172](https://kaltura.atlassian.net/browse/FEC-14172)
related pr: https://github.com/kaltura/playkit-js-ui/pull/950

[FEC-14172]: https://kaltura.atlassian.net/browse/FEC-14172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ