### PR TITLE
fix(ADA-1920): University of California - Berkeley | Boundaries Quiz Completed & Submitted Dialogs are not exposed to Screen Reader Users

### DIFF
--- a/src/components/ivq-popup/ivq-popup.tsx
+++ b/src/components/ivq-popup/ivq-popup.tsx
@@ -90,7 +90,7 @@ export const IvqPopup = withText(translates)(({type, onClose, onSubmit, onReview
     popupClasses.push(styles.completed);
   }
   return (
-    <div className={popupClasses.join(' ')} data-testid="ivqPopupRoot">
+    <div className={popupClasses.join(' ')} data-testid="ivqPopupRoot" role="alert">
       <A11yWrapper onClick={onClose}>
         <div tabIndex={0} className={styles.closeButton} aria-label={otherProps.closeButton} data-testid="ivqPopupCloseButton">
           <Icon


### PR DESCRIPTION
**Issue:**
Screen reader doesn't announce the popup alerts like "quiz completed/quiz submitted" and etc so screen reader users are not aware to this info.

**Fix:** 
Add role alert on the pop element so when it pops the screen reader will announce the content immediately.

Solves [ADA-1920](https://kaltura.atlassian.net/browse/ADA-1920)

[ADA-1920]: https://kaltura.atlassian.net/browse/ADA-1920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ