### PR TITLE
fix(FEC-14262): Player v7 | Quiz | Wrong first element focus on quiz questions overlay.

### DIFF
--- a/src/components/quiz-question/multi-choice/multi-choice.tsx
+++ b/src/components/quiz-question/multi-choice/multi-choice.tsx
@@ -35,7 +35,6 @@ export const MultiChoice = withText(translates)(
   }: QuestionProps & MultiChoiceProps & QuizTranslates) => {
     const selectedArray = selected ? selected.split(',') : [];
     const disabled = !onSelect;
-    const quizQuestionRef = useRef<HTMLLegendElement>(null);
     let answersOptionsRefMap: Map<number, HTMLElement | null> = new Map();
 
     useEffect(() => {
@@ -83,7 +82,7 @@ export const MultiChoice = withText(translates)(
 
     return (
       <div className={styles.multiChoiceWrapper} data-testid="multipleChoiceContainer">
-        <legend className={styles.questionText} data-testid="multipleChoiceQuestionTitle" ref={quizQuestionRef}>
+        <legend className={styles.questionText} data-testid="multipleChoiceQuestionTitle">
           <span className={styles.visuallyHidden}>{`${otherProps.questionLabel} #${questionIndex}:`}</span>
           <div dangerouslySetInnerHTML={{ __html: wrapLinksWithTags(question) }} />
         </legend>

--- a/src/components/quiz-question/multi-choice/multi-choice.tsx
+++ b/src/components/quiz-question/multi-choice/multi-choice.tsx
@@ -40,7 +40,7 @@ export const MultiChoice = withText(translates)(
 
     useEffect(() => {
       if (!disabled) {
-        quizQuestionRef.current?.focus();
+        answersOptionsRefMap.get(0)?.focus();
       }
     }, [question]);
 

--- a/src/components/quiz-question/open-question/open-question.tsx
+++ b/src/components/quiz-question/open-question/open-question.tsx
@@ -28,7 +28,6 @@ export const OpenQuestion = withText(translates)(
       [onSelect]
     );
 
-    const quizQuestionRef = useRef<HTMLLegendElement>(null);
     useEffect(() => {
       if (!disabled) {
         textareaRef.current?.focus();
@@ -37,7 +36,7 @@ export const OpenQuestion = withText(translates)(
 
     return (
       <div className={styles.openQuestionWrapper} data-testid="openQuestionContainer">
-        <legend className={styles.questionText} data-testid="openQuestionTitle" ref={quizQuestionRef}>
+        <legend className={styles.questionText} data-testid="openQuestionTitle">
           <span className={styles.visuallyHidden}>{`${otherProps.questionLabel} #${questionIndex}:`}</span>
           <div dangerouslySetInnerHTML={{__html: wrapLinksWithTags(question)}} />
         </legend>

--- a/src/components/quiz-question/open-question/open-question.tsx
+++ b/src/components/quiz-question/open-question/open-question.tsx
@@ -19,6 +19,7 @@ const translates = (): QuizTranslates => {
 export const OpenQuestion = withText(translates)(
   ({question, selected, onSelect, hint, questionIndex, ...otherProps}: QuestionProps & QuizTranslates) => {
     const disabled = !onSelect;
+      const textareaRef = useRef<HTMLTextAreaElement>(null);
 
     const handleChange = useCallback(
       (e: any) => {
@@ -31,6 +32,7 @@ export const OpenQuestion = withText(translates)(
     useEffect(() => {
       if (!disabled) {
         quizQuestionRef.current?.focus();
+          textareaRef.current?.focus();
       }
     }, [question]);
 
@@ -52,6 +54,7 @@ export const OpenQuestion = withText(translates)(
             onChange={handleChange}
             disabled={disabled}
             data-testid="openQuestionAnswerInput"
+            ref={textareaRef}
           />
           <div className={styles.charCounter}>{`${selected.length}/${MAX_LENGTH}`}</div>
         </div>

--- a/src/components/quiz-question/open-question/open-question.tsx
+++ b/src/components/quiz-question/open-question/open-question.tsx
@@ -31,8 +31,7 @@ export const OpenQuestion = withText(translates)(
     const quizQuestionRef = useRef<HTMLLegendElement>(null);
     useEffect(() => {
       if (!disabled) {
-        quizQuestionRef.current?.focus();
-          textareaRef.current?.focus();
+        textareaRef.current?.focus();
       }
     }, [question]);
 

--- a/src/components/quiz-question/quiz-question-wrapper.tsx
+++ b/src/components/quiz-question/quiz-question-wrapper.tsx
@@ -72,7 +72,11 @@ export const QuizQuestionWrapper = withText(translates)((props: QuizQuestionWrap
   useEffect(() => {
     setSelected(getSelected(qui));
     setIsLoading(false);
+    if(qui.q.questionType === KalturaQuizQuestionTypes.Reflection){
+      continueButtonRef.current?.focus();
+    }
   }, [qui]);
+
 
   const handleContinue = useCallback(() => {
     if (!selected) {
@@ -134,7 +138,7 @@ export const QuizQuestionWrapper = withText(translates)((props: QuizQuestionWrap
       case KalturaQuizQuestionTypes.MultiChoice:
         return <MultiChoice {...questionProps} />;
       case KalturaQuizQuestionTypes.Reflection:
-        return <ReflectionPoint {...questionProps} continueButton={continueButtonRef}/>;
+        return <ReflectionPoint {...questionProps}/>;
       case KalturaQuizQuestionTypes.OpenQuestion:
         return <OpenQuestion {...questionProps} />;
       case KalturaQuizQuestionTypes.MultiAnswer:

--- a/src/components/quiz-question/quiz-question-wrapper.tsx
+++ b/src/components/quiz-question/quiz-question-wrapper.tsx
@@ -134,7 +134,7 @@ export const QuizQuestionWrapper = withText(translates)((props: QuizQuestionWrap
       case KalturaQuizQuestionTypes.MultiChoice:
         return <MultiChoice {...questionProps} />;
       case KalturaQuizQuestionTypes.Reflection:
-        return <ReflectionPoint {...questionProps} />;
+        return <ReflectionPoint {...questionProps} continueButton={continueButtonRef}/>;
       case KalturaQuizQuestionTypes.OpenQuestion:
         return <OpenQuestion {...questionProps} />;
       case KalturaQuizQuestionTypes.MultiAnswer:

--- a/src/components/quiz-question/quiz-question-wrapper.tsx
+++ b/src/components/quiz-question/quiz-question-wrapper.tsx
@@ -63,9 +63,6 @@ export const QuizQuestionWrapper = withText(translates)((props: QuizQuestionWrap
       if (!playerNav) {
         return;
       }
-      if (qui.a) {
-        continueButtonRef.current?.focus();
-      }
     });
   }, [qui]);
 

--- a/src/components/quiz-question/quiz-question-wrapper.tsx
+++ b/src/components/quiz-question/quiz-question-wrapper.tsx
@@ -72,7 +72,7 @@ export const QuizQuestionWrapper = withText(translates)((props: QuizQuestionWrap
   useEffect(() => {
     setSelected(getSelected(qui));
     setIsLoading(false);
-    if(qui.q.questionType === KalturaQuizQuestionTypes.Reflection){
+    if(qui.a || qui.q.questionType === KalturaQuizQuestionTypes.Reflection){
       continueButtonRef.current?.focus();
     }
   }, [qui]);

--- a/src/components/quiz-question/reflection-point/reflection-point.tsx
+++ b/src/components/quiz-question/reflection-point/reflection-point.tsx
@@ -1,14 +1,10 @@
-import {h, RefObject} from 'preact';
+import {h} from 'preact';
 import {useEffect, useRef} from 'preact/hooks';
 import {QuestionProps, QuizTranslates} from '../../../types';
 import * as styles from './reflection-point.scss';
 import {wrapLinksWithTags} from '../../../utils';
 
 const {withText, Text} = KalturaPlayer.ui.preacti18n;
-
-interface reflectionPointProps {
-  continueButton: RefObject<HTMLDivElement>;
-}
 
 const translates = (): QuizTranslates => {
   return {
@@ -17,15 +13,11 @@ const translates = (): QuizTranslates => {
   };
 };
 
-export const ReflectionPoint = withText(translates)(({question, questionIndex, ...otherProps}: QuestionProps & QuizTranslates & reflectionPointProps) => {
-  const quizQuestionRef = useRef<HTMLLegendElement>(null);
-  useEffect(() => {
-    otherProps.continueButton.current?.focus();
-  }, [question]);
+export const ReflectionPoint = withText(translates)(({question, questionIndex, ...otherProps}: QuestionProps & QuizTranslates) => {
 
   return (
     <div className={styles.reflectionPointWrapper}>
-      <legend className={styles.reflectionText} data-testid="reflectionPointTitle" ref={quizQuestionRef}>
+      <legend className={styles.reflectionText} data-testid="reflectionPointTitle">
         <span className={styles.visuallyHidden}>{`${otherProps.questionLabel}# ${questionIndex}, ${otherProps.reflectionPoint}:`}</span>
         <div dangerouslySetInnerHTML={{ __html: wrapLinksWithTags(question) }} />
       </legend>

--- a/src/components/quiz-question/reflection-point/reflection-point.tsx
+++ b/src/components/quiz-question/reflection-point/reflection-point.tsx
@@ -1,10 +1,14 @@
-import {h} from 'preact';
+import {h, RefObject} from 'preact';
 import {useEffect, useRef} from 'preact/hooks';
 import {QuestionProps, QuizTranslates} from '../../../types';
 import * as styles from './reflection-point.scss';
 import {wrapLinksWithTags} from '../../../utils';
 
 const {withText, Text} = KalturaPlayer.ui.preacti18n;
+
+interface reflectionPointProps {
+  continueButton: RefObject<HTMLDivElement>;
+}
 
 const translates = (): QuizTranslates => {
   return {
@@ -13,10 +17,10 @@ const translates = (): QuizTranslates => {
   };
 };
 
-export const ReflectionPoint = withText(translates)(({question, questionIndex, ...otherProps}: QuestionProps & QuizTranslates) => {
+export const ReflectionPoint = withText(translates)(({question, questionIndex, ...otherProps}: QuestionProps & QuizTranslates & reflectionPointProps) => {
   const quizQuestionRef = useRef<HTMLLegendElement>(null);
   useEffect(() => {
-    quizQuestionRef.current?.focus();
+    otherProps.continueButton.current?.focus();
   }, [question]);
 
   return (

--- a/src/components/quiz-question/true-false/true-false.tsx
+++ b/src/components/quiz-question/true-false/true-false.tsx
@@ -27,7 +27,7 @@ export const TrueFalse = withText(translates)(
     const quizQuestionRef = useRef<HTMLLegendElement>(null);
     useEffect(() => {
       if (!disabled) {
-        quizQuestionRef.current?.focus();
+        answersOptionsRefMap.get(0)?.focus();
       }
     }, [question]);
 

--- a/src/components/quiz-question/true-false/true-false.tsx
+++ b/src/components/quiz-question/true-false/true-false.tsx
@@ -24,7 +24,6 @@ export const TrueFalse = withText(translates)(
       },
       [onSelect]
     );
-    const quizQuestionRef = useRef<HTMLLegendElement>(null);
     useEffect(() => {
       if (!disabled) {
         answersOptionsRefMap.get(0)?.focus();
@@ -56,7 +55,7 @@ export const TrueFalse = withText(translates)(
 
     return (
       <div className={styles.trueFalseWrapper} data-testid="trueFalseContainer">
-        <legend className={styles.questionText} data-testid="trueFalseQuestionTitle" ref={quizQuestionRef}>
+        <legend className={styles.questionText} data-testid="trueFalseQuestionTitle">
           <span className={styles.visuallyHidden}>{`${otherProps.questionLabel} #${questionIndex}:`}</span>
           <div dangerouslySetInnerHTML={{ __html: wrapLinksWithTags(question) }} />
         </legend>


### PR DESCRIPTION
Issue: 
When question overlay is opened, focus is not moved to first element in the overlay.

Root cause: 
tabindex=0 was removed from legend element since it's not an interactive element.

Fix:
Move the focus to first interactive element in the overlay instead of to legend element.

Solves [FEC-14262](https://kaltura.atlassian.net/browse/FEC-14262)

[FEC-14262]: https://kaltura.atlassian.net/browse/FEC-14262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ