### PR TITLE
fix(ADA-1990): [IU] Redundant Screen Reader Announcement for Quiz Player Answer Options

### DIFF
--- a/src/components/quiz-question/multi-choice/multi-choice.tsx
+++ b/src/components/quiz-question/multi-choice/multi-choice.tsx
@@ -10,7 +10,6 @@ const {withText, Text} = KalturaPlayer.ui.preacti18n;
 
 const translates = (): QuizTranslates => {
   return {
-    answerNumber: <Text id="ivq.answer_number">answer number</Text>,
     yourAnswer: <Text id="ivq.your_answer">Your answer</Text>,
     questionLabel: <Text id="ivq.question">Question</Text>
   };
@@ -107,7 +106,7 @@ export const MultiChoice = withText(translates)(
                     aria-checked={isActive}
                     aria-disabled={disabled}
                     aria-multiselectable={Boolean(multiAnswer)}
-                    aria-label={`${otherProps.answerNumber} ${index + 1}, ${text}${isActive ? `. ${otherProps.yourAnswer}` : ''}`}
+                    aria-label={`${questionLabels[index]}, ${text}${isActive ? `. ${otherProps.yourAnswer}` : ''}`}
                     className={[styles.multiSelectAnswer, isActive ? styles.active : '', disabled ? styles.disabled : ''].join(' ')}>
                     <div className={styles.questionLabel} data-testid="multipleChoiceQuestionLabel">
                       {questionLabels[index]}


### PR DESCRIPTION

Change the aria-label of answer in multi choice to be the letter + answer content instead "Answer number x"

Solves [ADA-1990](https://kaltura.atlassian.net/browse/ADA-1990)

[ADA-1990]: https://kaltura.atlassian.net/browse/ADA-1990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ