### PR TITLE
fix(SUP-45709): IVQ Editor - No Seeking forward Alert for V7 player

### DIFF
--- a/src/data-sync-manager.ts
+++ b/src/data-sync-manager.ts
@@ -112,6 +112,7 @@ export class DataSyncManager {
       this._logger.warn('initDataManager: quizData or quizUserEntry absent');
       return;
     }
+
     if ((this.quizData.preventSeek && !allowSeek) || this._player.ui.store.getState().seekbar.isPreventSeek) {
       this._enableSeekControl();
     }

--- a/src/ivq.tsx
+++ b/src/ivq.tsx
@@ -431,10 +431,9 @@ export class Ivq extends KalturaPlayer.core.BasePlugin {
     if(!this.isNoSeekAlertShown) {
       this.toastManager.add({
         icon: null,
-        onClick(): void {
-        },
+        onClick(): void {},
         severity: 'Error',
-        title: (<Text id="ivq.seeking_is_disable_popup_title"></Text>) as any,
+        title: (<Text id="ivq.seeking_is_disable_popup_title">Seeking was disabled on this video</Text>) as any,
         text: '',
         duration: this.defaultToastDuration
       })

--- a/src/ivq.tsx
+++ b/src/ivq.tsx
@@ -3,7 +3,7 @@ import {h} from 'preact';
 import {core} from '@playkit-js/kaltura-player-js';
 // @ts-ignore
 import {Env} from '@playkit-js/playkit-js';
-import {FloatingItem, FloatingManager, ToastManager, ToastSeverity} from '@playkit-js/ui-managers';
+import {FloatingItem, FloatingManager, ToastManager} from '@playkit-js/ui-managers';
 import {QuizLoader} from './providers';
 import {
   IvqConfig,

--- a/src/ivq.tsx
+++ b/src/ivq.tsx
@@ -1,10 +1,11 @@
 import {h} from 'preact';
 // @ts-ignore
-import {core} from '@playkit-js/kaltura-player-js';
+import {core, ui} from '@playkit-js/kaltura-player-js';
 // @ts-ignore
 import {Env} from '@playkit-js/playkit-js';
 import {FloatingItem, FloatingManager, ToastManager} from '@playkit-js/ui-managers';
 import {QuizLoader} from './providers';
+
 import {
   IvqConfig,
   IvqEventTypes,
@@ -29,6 +30,7 @@ import {KalturaIvqMiddleware} from './quiz-middleware';
 const {EventType} = core;
 
 const HAS_IVQ_OVERLAY_CLASSNAME = 'has-ivq-plugin-overlay';
+const {Text} = KalturaPlayer.ui.preacti18n;
 
 export const PLUGIN_NAME = 'ivq';
 
@@ -424,16 +426,16 @@ export class Ivq extends KalturaPlayer.core.BasePlugin {
     return this._seekControlEnabled && !this._questionsVisualManager.quizQuestionJumping && to > this._maxCurrentTime;
   };
 
+
   private _showNoSeekAlertPopUp = () => {
-    const noSeekAlertText = "Seeking was disabled on this video";
     if(!this.isNoSeekAlertShown) {
       this.toastManager.add({
         icon: null,
         onClick(): void {
         },
         severity: 'Error',
-        title: '',
-        text: noSeekAlertText,
+        title: (<Text id="ivq.seeking_is_disable_popup_title"></Text>) as any,
+        text: '',
         duration: this.defaultToastDuration
       })
     }

--- a/src/ivq.tsx
+++ b/src/ivq.tsx
@@ -45,6 +45,7 @@ export class Ivq extends KalturaPlayer.core.BasePlugin {
   private _removeActiveOverlay: null | Function = null;
   private _ivqPopup: null | FloatingItem = null;
   private _playlistOptions: null | KalturaPlayerTypes.Playlist['options'] = null;
+  private isNoSeekAlertShown = false;
   private defaultToastDuration = 5 * 1000;
 
   static defaultConfig: IvqConfig = {};
@@ -424,15 +425,22 @@ export class Ivq extends KalturaPlayer.core.BasePlugin {
   };
 
   private _showNoSeekAlertPopUp = () => {
-    const noSeekAlertText = this._dataManager.quizData?.noSeekAlertText
-    this.toastManager.add({
-      icon: null,
-      onClick(): void {},
-      severity: 'Info',
-      title: noSeekAlertText ?? 'default',
-      text: ' ',
-      duration: this.defaultToastDuration
-    })
+    const noSeekAlertText = "Seeking was disabled on this video";
+    if(!this.isNoSeekAlertShown) {
+      this.toastManager.add({
+        icon: null,
+        onClick(): void {
+        },
+        severity: 'Error',
+        title: '',
+        text: noSeekAlertText,
+        duration: this.defaultToastDuration
+      })
+    }
+    this.isNoSeekAlertShown = true;
+    setTimeout(() => {
+      this.isNoSeekAlertShown = false;
+    }, this.defaultToastDuration)
   };
 
   private _onQuizRetake = (): Promise<void> => {

--- a/src/ivq.tsx
+++ b/src/ivq.tsx
@@ -1,6 +1,6 @@
 import {h} from 'preact';
 // @ts-ignore
-import {core, ui} from '@playkit-js/kaltura-player-js';
+import {core} from '@playkit-js/kaltura-player-js';
 // @ts-ignore
 import {Env} from '@playkit-js/playkit-js';
 import {FloatingItem, FloatingManager, ToastManager, ToastSeverity} from '@playkit-js/ui-managers';

--- a/src/quiz-middleware.ts
+++ b/src/quiz-middleware.ts
@@ -1,10 +1,16 @@
 export class KalturaIvqMiddleware extends KalturaPlayer.core.BaseMiddleware {
-  constructor(private _shouldPreventSeek: (to: number) => boolean) {
+  constructor(
+    private _shouldPreventSeek: (to: number) => boolean,
+    private _showNoSeekAlertMessage: () => void
+  ) {
     super();
   }
 
+
   setCurrentTime(to: number, next: Function) {
     if (this._shouldPreventSeek(to)) {
+      this._showNoSeekAlertMessage()
+   //   console.log("_preventSeekAlertText " + this._getSeekAlertText())
       return;
     }
     this.callNext(next);

--- a/src/quiz-middleware.ts
+++ b/src/quiz-middleware.ts
@@ -10,7 +10,6 @@ export class KalturaIvqMiddleware extends KalturaPlayer.core.BaseMiddleware {
   setCurrentTime(to: number, next: Function) {
     if (this._shouldPreventSeek(to)) {
       this._showNoSeekAlertMessage()
-   //   console.log("_preventSeekAlertText " + this._getSeekAlertText())
       return;
     }
     this.callNext(next);

--- a/translations/en.i18n.json
+++ b/translations/en.i18n.json
@@ -49,7 +49,8 @@
       "quiz_almost_done_description": "It appears that some questions remained unanswered You must answer all questions before you can submit",
       "quiz_submit_description": "Take a moment to review your answers or go ahead to submit your answers.",
       "quiz_completed_description": "Watch the video until the end to submit.",
-      "quiz_submitted_title": "Quiz submitted"
+      "quiz_submitted_title": "Quiz submitted",
+      "seeking_is_disable_popup_title": "Seeking was disabled on this video"
     }
   }
 }


### PR DESCRIPTION
Issue:
When user tries to seek but prevent due to the quiz prevent seeking checkbox on KMS, he is unable to seek.

Fix:
Suppose to show an alert pop up with default message.

solved-[SUP-45709](https://kaltura.atlassian.net/browse/SUP-45709)

[SUP-45709]: https://kaltura.atlassian.net/browse/SUP-45709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ