### PR TITLE
fix (SUP-46685):  Multiple Chapters in Quiz Break the Timeline

### DIFF
--- a/src/components/ivq-bottom-bar/ivq-bottom-bar.tsx
+++ b/src/components/ivq-bottom-bar/ivq-bottom-bar.tsx
@@ -13,7 +13,7 @@ interface IvqBottomBarProps {
   onNext?: OnClick;
   questionCounter: string | VNode<{}>;
   getSeekBarNode: () => Element | null;
-  updateHover: () => void;
+  updatePlayerHover: () => void;
 }
 
 const translates: QuizTranslates = {
@@ -22,10 +22,11 @@ const translates: QuizTranslates = {
 };
 
 export const IvqBottomBar = withText(translates)(
-  ({onPrev, onNext, questionCounter, getSeekBarNode, updateHover, ...otherProps}: IvqBottomBarProps & QuizTranslates) => {
+  ({onPrev, onNext, questionCounter, getSeekBarNode, updatePlayerHover, ...otherProps}: IvqBottomBarProps & QuizTranslates) => {
     const ivqBottomBarRef = useRef<HTMLDivElement>(null);
     useLayoutEffect(() => {
-      window.dispatchEvent(new Event('updateHover'));
+      // window.dispatchEvent(new Event('updateHover'));
+      updatePlayerHover();
       const seekBarNode = getSeekBarNode();
       if (ivqBottomBarRef.current && seekBarNode) {
         // inject player seek bar into IvqBottomBar component

--- a/src/components/ivq-bottom-bar/ivq-bottom-bar.tsx
+++ b/src/components/ivq-bottom-bar/ivq-bottom-bar.tsx
@@ -1,5 +1,5 @@
 import {h, VNode} from 'preact';
-import {useMemo, useEffect, useRef} from 'preact/hooks';
+import {useMemo, useRef, useLayoutEffect} from 'preact/hooks';
 import {A11yWrapper, OnClick} from '@playkit-js/common/dist/hoc/a11y-wrapper';
 import {icons} from '../icons';
 import {QuizTranslates} from '../../types';
@@ -13,6 +13,7 @@ interface IvqBottomBarProps {
   onNext?: OnClick;
   questionCounter: string | VNode<{}>;
   getSeekBarNode: () => Element | null;
+  updateHover: () => void;
 }
 
 const translates: QuizTranslates = {
@@ -21,9 +22,10 @@ const translates: QuizTranslates = {
 };
 
 export const IvqBottomBar = withText(translates)(
-  ({onPrev, onNext, questionCounter, getSeekBarNode, ...otherProps}: IvqBottomBarProps & QuizTranslates) => {
+  ({onPrev, onNext, questionCounter, getSeekBarNode, updateHover, ...otherProps}: IvqBottomBarProps & QuizTranslates) => {
     const ivqBottomBarRef = useRef<HTMLDivElement>(null);
-    useEffect(() => {
+    useLayoutEffect(() => {
+      window.dispatchEvent(new Event('updateHover'));
       const seekBarNode = getSeekBarNode();
       if (ivqBottomBarRef.current && seekBarNode) {
         // inject player seek bar into IvqBottomBar component

--- a/src/components/ivq-bottom-bar/ivq-bottom-bar.tsx
+++ b/src/components/ivq-bottom-bar/ivq-bottom-bar.tsx
@@ -25,7 +25,6 @@ export const IvqBottomBar = withText(translates)(
   ({onPrev, onNext, questionCounter, getSeekBarNode, updatePlayerHover, ...otherProps}: IvqBottomBarProps & QuizTranslates) => {
     const ivqBottomBarRef = useRef<HTMLDivElement>(null);
     useLayoutEffect(() => {
-      // window.dispatchEvent(new Event('updateHover'));
       updatePlayerHover();
       const seekBarNode = getSeekBarNode();
       if (ivqBottomBarRef.current && seekBarNode) {

--- a/src/components/quiz-question/quiz-question-wrapper.tsx
+++ b/src/components/quiz-question/quiz-question-wrapper.tsx
@@ -20,6 +20,7 @@ const {
 interface QuizQuestionWrapperProps {
   qui: QuizQuestionUI;
   getSeekBarNode: Element | null;
+  updatePlayerHover: () => void;
 }
 
 const translates = ({qui}: QuizQuestionWrapperProps): QuizTranslates => {
@@ -51,7 +52,7 @@ const getSelected = (qui: QuizQuestionUI): string => {
 };
 
 export const QuizQuestionWrapper = withText(translates)((props: QuizQuestionWrapperProps & QuizTranslates) => {
-  const {qui, getSeekBarNode} = props;
+  const {qui, getSeekBarNode, updatePlayerHover} = props;
   const [selected, setSelected] = useState<Selected>(getSelected(qui));
   const [isLoading, setIsLoading] = useState(false);
   const continueButtonRef = useRef<HTMLDivElement>(null);
@@ -185,7 +186,13 @@ export const QuizQuestionWrapper = withText(translates)((props: QuizQuestionWrap
         </div>
         {renderIvqButtons}
       </div>
-      <IvqBottomBar questionCounter={props.questionCounter} onPrev={qui.onPrev} onNext={qui.onNext} getSeekBarNode={getSeekBarNode} />
+      <IvqBottomBar
+        questionCounter={props.questionCounter}
+        onPrev={qui.onPrev}
+        onNext={qui.onNext}
+        getSeekBarNode={getSeekBarNode}
+        updatePlayerHover={updatePlayerHover}
+      />
     </IvqOverlay>
   );
 });

--- a/src/components/quiz-review/question-review/question-review.tsx
+++ b/src/components/quiz-review/question-review/question-review.tsx
@@ -25,6 +25,7 @@ interface QuestionReviewProps {
   onBack: () => void;
   reviewQuestion: ReviewQuestion;
   getSeekBarNode: () => Element | null;
+  updatePlayerHover: () => void;
 }
 
 const translates = ({questionsAmount, reviewQuestion}: QuestionReviewProps): QuizTranslates => {
@@ -45,7 +46,16 @@ const translates = ({questionsAmount, reviewQuestion}: QuestionReviewProps): Qui
 };
 
 export const QuestionReview = withText(translates)(
-  ({onBack, onNext, onPrev, questionCounter, reviewQuestion, getSeekBarNode, ...otherProps}: QuestionReviewProps & QuizTranslates) => {
+  ({
+    onBack,
+    onNext,
+    onPrev,
+    questionCounter,
+    reviewQuestion,
+    getSeekBarNode,
+    updatePlayerHover,
+    ...otherProps
+  }: QuestionReviewProps & QuizTranslates) => {
     const backButtonRef = useRef<HTMLDivElement>(null);
     const {q, a} = reviewQuestion.qq;
 
@@ -173,7 +183,13 @@ export const QuestionReview = withText(translates)(
             {renderCorrectAnswers}
           </div>
         </div>
-        <IvqBottomBar questionCounter={questionCounter} onPrev={onPrev} onNext={onNext} getSeekBarNode={getSeekBarNode} />
+        <IvqBottomBar
+          questionCounter={questionCounter}
+          onPrev={onPrev}
+          onNext={onNext}
+          getSeekBarNode={getSeekBarNode}
+          updatePlayerHover={updatePlayerHover}
+        />
       </Fragment>
     );
   }

--- a/src/components/quiz-review/quiz-review.tsx
+++ b/src/components/quiz-review/quiz-review.tsx
@@ -15,9 +15,17 @@ export interface QuizReviewProps {
   showScores: boolean;
   getSeekBarNode: () => Element | null;
   restoreSeekBar: () => void;
+  updatePlayerHover: () => void;
 }
 
-export const QuizReview = ({reviewDetails, preparePlayer, getSeekBarNode, restoreSeekBar, ...questionListReviewProps}: QuizReviewProps) => {
+export const QuizReview = ({
+  reviewDetails,
+  preparePlayer,
+  getSeekBarNode,
+  restoreSeekBar,
+  updatePlayerHover,
+  ...questionListReviewProps
+}: QuizReviewProps) => {
   const [reviewQuestion, setReviewQuestion] = useState<ReviewQuestion | null>(null);
 
   const handleQuestionClick = useCallback(
@@ -60,6 +68,7 @@ export const QuizReview = ({reviewDetails, preparePlayer, getSeekBarNode, restor
         reviewQuestion={reviewQuestion}
         questionsAmount={reviewDetails.length}
         getSeekBarNode={getSeekBarNode}
+        updatePlayerHover={updatePlayerHover}
       />
     );
   }, [reviewQuestion, reviewDetails, getSeekBarNode]);

--- a/src/ivq.tsx
+++ b/src/ivq.tsx
@@ -28,7 +28,7 @@ import {QuizDownloadLoader} from './providers/quiz-download-loader';
 import {KalturaIvqMiddleware} from './quiz-middleware';
 
 const {EventType, FakeEvent} = core;
-const {PLAYER_HOVER_STATE_CHANGED} = KalturaPlayer.ui.EventType;
+const {PLAYER_HOVERED} = KalturaPlayer.ui.EventType;
 
 const HAS_IVQ_OVERLAY_CLASSNAME = 'has-ivq-plugin-overlay';
 const {Text} = KalturaPlayer.ui.preacti18n;
@@ -142,7 +142,7 @@ export class Ivq extends KalturaPlayer.core.BasePlugin {
   };
 
   private _updatePlayerHover = () => {
-    this._player.dispatchEvent(new FakeEvent(PLAYER_HOVER_STATE_CHANGED));
+    this._player.dispatchEvent(new FakeEvent(PLAYER_HOVERED));
   };
 
   private _restoreSeekBar = () => {

--- a/src/ivq.tsx
+++ b/src/ivq.tsx
@@ -1,6 +1,6 @@
 import {h} from 'preact';
 // @ts-ignore
-import {core, FakeEvent} from '@playkit-js/kaltura-player-js';
+import {core} from '@playkit-js/kaltura-player-js';
 // @ts-ignore
 import {Env} from '@playkit-js/playkit-js';
 import {FloatingItem, FloatingManager, ToastManager} from '@playkit-js/ui-managers';

--- a/src/ivq.tsx
+++ b/src/ivq.tsx
@@ -1,6 +1,6 @@
 import {h} from 'preact';
 // @ts-ignore
-import {core, ui} from '@playkit-js/kaltura-player-js';
+import {core, FakeEvent} from '@playkit-js/kaltura-player-js';
 // @ts-ignore
 import {Env} from '@playkit-js/playkit-js';
 import {FloatingItem, FloatingManager, ToastManager} from '@playkit-js/ui-managers';
@@ -27,7 +27,8 @@ import {IvqPopup, IvqPopupProps, IvqPopupTypes} from './components/ivq-popup';
 import {QuizDownloadLoader} from './providers/quiz-download-loader';
 import {KalturaIvqMiddleware} from './quiz-middleware';
 
-const {EventType} = core;
+const {EventType, FakeEvent} = core;
+const {PLAYER_HOVER_STATE_CHANGED} = KalturaPlayer.ui.EventType;
 
 const HAS_IVQ_OVERLAY_CLASSNAME = 'has-ivq-plugin-overlay';
 const {Text} = KalturaPlayer.ui.preacti18n;
@@ -78,7 +79,8 @@ export class Ivq extends KalturaPlayer.core.BasePlugin {
       this._removeOverlay,
       () => Boolean(this._removeActiveOverlay),
       this._getSeekBarNode,
-      this._dataManager.dispatchQuestionChanged
+      this._dataManager.dispatchQuestionChanged,
+      this._updatePlayerHover
     );
     this._registerQuizApi();
   }
@@ -137,6 +139,10 @@ export class Ivq extends KalturaPlayer.core.BasePlugin {
 
   private _getSeekBarNode = () => {
     return this._player.getView().parentNode?.parentNode?.querySelector(KalturaPlayerSeekBarSelector) || null;
+  };
+
+  private _updatePlayerHover = () => {
+    this._player.dispatchEvent(new FakeEvent(PLAYER_HOVER_STATE_CHANGED));
   };
 
   private _restoreSeekBar = () => {
@@ -355,7 +361,8 @@ export class Ivq extends KalturaPlayer.core.BasePlugin {
               showScores: showGradeAfterSubmission,
               preparePlayer: this._questionsVisualManager.preparePlayer,
               getSeekBarNode: this._getSeekBarNode,
-              restoreSeekBar: this._restoreSeekBar
+              restoreSeekBar: this._restoreSeekBar,
+              updatePlayerHover: this._updatePlayerHover
             };
             if (this._dataManager.isRetakeAllowed()) {
               params.onRetake = () => {
@@ -426,9 +433,8 @@ export class Ivq extends KalturaPlayer.core.BasePlugin {
     return this._seekControlEnabled && !this._questionsVisualManager.quizQuestionJumping && to > this._maxCurrentTime;
   };
 
-
   private _showNoSeekAlertPopUp = () => {
-    if(!this.isNoSeekAlertShown) {
+    if (!this.isNoSeekAlertShown) {
       this.toastManager.add({
         icon: null,
         onClick(): void {},
@@ -436,12 +442,12 @@ export class Ivq extends KalturaPlayer.core.BasePlugin {
         title: (<Text id="ivq.seeking_is_disable_popup_title">Seeking was disabled on this video</Text>) as any,
         text: '',
         duration: this.defaultToastDuration
-      })
+      });
     }
     this.isNoSeekAlertShown = true;
     setTimeout(() => {
       this.isNoSeekAlertShown = false;
-    }, this.defaultToastDuration)
+    }, this.defaultToastDuration);
   };
 
   private _onQuizRetake = (): Promise<void> => {

--- a/src/questions-visual-manager.tsx
+++ b/src/questions-visual-manager.tsx
@@ -11,8 +11,9 @@ import {
   KalturaQuizQuestionTypes,
   SubmissionDetails,
   PresetAreas,
-  UiComponentArea, IvqEventTypes
-} from "./types";
+  UiComponentArea,
+  IvqEventTypes
+} from './types';
 import {QuizQuestionWrapper} from './components/quiz-question';
 
 const {EventType, FakeEvent} = core;
@@ -33,7 +34,8 @@ export class QuestionsVisualManager {
     private _removeOverlay: () => void,
     private _isOverlayExist: () => boolean,
     private _getSeekBarNode: () => Element | null,
-    private _dispatchQuestionChanged: () => void
+    private _dispatchQuestionChanged: () => void,
+    private _updatePlayerHover: () => void
   ) {
     this._eventManager.listen(this._player, EventType.SEEKING, this._resetLastQuizCuePointId);
   }
@@ -98,7 +100,9 @@ export class QuestionsVisualManager {
             this._updateQuestionComponent = (qui: QuizQuestionUI) => {
               setQui(qui);
             };
-            return <QuizQuestionWrapper qui={qui || quizQuestionUi} getSeekBarNode={this._getSeekBarNode} />;
+            return (
+              <QuizQuestionWrapper qui={qui || quizQuestionUi} getSeekBarNode={this._getSeekBarNode} updatePlayerHover={this._updatePlayerHover} />
+            );
           }
         })
       );
@@ -135,7 +139,7 @@ export class QuestionsVisualManager {
         this._removeOverlay();
         this._player.play();
       }
-      this._player.dispatchEvent(new FakeEvent(IvqEventTypes.QUIZ_SKIPPED, { questionIndex: qq.index + 1 }));
+      this._player.dispatchEvent(new FakeEvent(IvqEventTypes.QUIZ_SKIPPED, {questionIndex: qq.index + 1}));
     };
 
     const onContinue = (data: Selected | null) => {

--- a/translations/es.i18n.json
+++ b/translations/es.i18n.json
@@ -50,7 +50,7 @@
       "quiz_submit_description": "Tómese un momento para revisar sus respuestas o continúe para enviarlas.",
       "quiz_completed_description": "Mire el video hasta el final para poder enviarlo.",
       "quiz_submitted_title": "Cuestionario presentado",
-      "seeking_is_disable_popup_title": "La búsqueda está deshabilitada en este reproducto"
+      "seeking_is_disable_popup_title": "La búsqueda está deshabilitada en este reproductor"
     }
   }
 }


### PR DESCRIPTION
**Issue:**
The question appears a few seconds earlier than expected on the timeline.
Root Cause:
The issue stems from the player hover state not being updated. As a result:
The bottom bar doesn’t adjust its width correctly.
This prevents the seek bar from updating its width.
The incorrect seek bar width leads to miscalculations in the question timing.

**Fix:**
To resolve this, an event is dispatched within useLayoutEffect, right before the browser paints the element. This ensures that the seek bar’s dimensions are recalculated correctly, resulting in accurate question timing on the timeline.

solved [SUP-46685](https://kaltura.atlassian.net/browse/SUP-46685)

[SUP-46685]: https://kaltura.atlassian.net/browse/SUP-46685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ