### PR TITLE
fix(FEC-14396): Fix for state locking on quiz retake

### DIFF
--- a/src/components/quiz-question/quiz-question-wrapper.tsx
+++ b/src/components/quiz-question/quiz-question-wrapper.tsx
@@ -97,6 +97,7 @@ export const QuizQuestionWrapper = withText(translates)((props: QuizQuestionWrap
     }
     qui.onContinue(newAnswer).finally(() => {
       setIsLoading(false);
+      updatePlayerHover();
     });
   }, [qui, selected]);
 

--- a/src/ivq.tsx
+++ b/src/ivq.tsx
@@ -146,6 +146,7 @@ export class Ivq extends KalturaPlayer.core.BasePlugin {
   };
 
   private _restoreSeekBar = () => {
+    this._updatePlayerHover();
     const seekBarParentNode = this._getBottomBarNode();
     if (seekBarParentNode && !seekBarParentNode?.querySelector(KalturaPlayerSeekBarSelector)) {
       const seekBarNode = this._getSeekBarNode();


### PR DESCRIPTION
Fix for https://kaltura.atlassian.net/browse/FEC-14396
The issue was caused in Firefox, when you go to quiz question back in timeline specifically clicking on question button.
The issue dissapeared after you do hover on any cuepoint of quiz, so i call resetHover after question is answered.