### PR TITLE
fix(SUP-47479): player with bumper prevents display of quiz timestamp on the timeline

### DIFF
--- a/src/ivq.tsx
+++ b/src/ivq.tsx
@@ -111,6 +111,11 @@ export class Ivq extends KalturaPlayer.core.BasePlugin {
         this._handlePlaylistConfiguration();
         this.eventManager.listen(this._player, this._player.Event.ENDED, this._handleEndEvent);
         this._disableNativePip();
+        this.eventManager.listen(this._player, this._player.Event.ALL_ADS_COMPLETED, () => {
+          const timelineService: any = this._player.getService('timeline');
+          timelineService.removeAllKalturaCuePoints()
+          this._handleTimeline(qqm); 
+        })
       });
     } else {
       this.logger.warn('kalturaCuepoints service is not registered or entry Live');

--- a/src/ivq.tsx
+++ b/src/ivq.tsx
@@ -111,11 +111,7 @@ export class Ivq extends KalturaPlayer.core.BasePlugin {
         this._handlePlaylistConfiguration();
         this.eventManager.listen(this._player, this._player.Event.ENDED, this._handleEndEvent);
         this._disableNativePip();
-        this.eventManager.listen(this._player, this._player.Event.ALL_ADS_COMPLETED, () => {
-          const timelineService: any = this._player.getService('timeline');
-          timelineService.removeAllKalturaCuePoints()
-          this._handleTimeline(qqm); 
-        })
+        this.eventManager.listen(this._player, this._player.Event.ALL_ADS_COMPLETED, () => this._handleAdsCompletedEvent(qqm))
       });
     } else {
       this.logger.warn('kalturaCuepoints service is not registered or entry Live');
@@ -235,6 +231,16 @@ export class Ivq extends KalturaPlayer.core.BasePlugin {
       this._displayQuizSubmit();
     }
   };
+
+  private _handleAdsCompletedEvent = (qqm: QuizQuestionMap) => {
+    const timelineService: any = this._player.getService('timeline');
+    qqm.forEach((qq: QuizQuestion) => {
+      if (qq.id) {
+        timelineService.removeCueFromTimeline({ id: qq.id , startTime: qq.startTime});
+      }
+    })
+    this._handleTimeline(qqm); 
+  }
 
   private _manageIvqPopup = (onInit = true) => {
     this.logger.debug("show 'IVQ Banner'");


### PR DESCRIPTION
**Issue:**
The cue-points of the IVQ questions are loaded when the ads are playing, therefore, they are not seen in the seek bar when the entry is playing.
The problem can be solved by add "disableMediaPreload": true, but on YouTube entry it doesn't work.

**Fix:**
When all the ads are completed, remove all the cue-points and put them again, in order to see them on the seekbar.

solved [SUP-47479](https://kaltura.atlassian.net/browse/SUP-47479)

[SUP-47479]: https://kaltura.atlassian.net/browse/SUP-47479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ