### PR TITLE
fix: (SUP-47479): player with bumper prevents display of quiz timestamp on the timeline

### DIFF
--- a/src/ivq.tsx
+++ b/src/ivq.tsx
@@ -111,6 +111,11 @@ export class Ivq extends KalturaPlayer.core.BasePlugin {
         this._handlePlaylistConfiguration();
         this.eventManager.listen(this._player, this._player.Event.ENDED, this._handleEndEvent);
         this._disableNativePip();
+        this.eventManager.listen(this._player, this._player.Event.ALL_ADS_COMPLETED, () => {
+          const timelineService: any = this._player.getService('timeline');
+          timelineService.removeAllKalturaCuePoints()
+          this._handleTimeline(qqm); 
+        })
       });
     } else {
       this.logger.warn('kalturaCuepoints service is not registered or entry Live');

--- a/src/ivq.tsx
+++ b/src/ivq.tsx
@@ -111,7 +111,8 @@ export class Ivq extends KalturaPlayer.core.BasePlugin {
         this._handlePlaylistConfiguration();
         this.eventManager.listen(this._player, this._player.Event.ENDED, this._handleEndEvent);
         this._disableNativePip();
-        this.eventManager.listen(this._player, this._player.Event.ALL_ADS_COMPLETED, () => this._handleAdsCompletedEvent(qqm))
+        this.eventManager.listen(this._player, this._player.Event.AD_SKIPPED, () => this._handleAdsCompletedEvent(qqm))
+        this.eventManager.listen(this._player, this._player.Event.AD_COMPLETED, () => this._handleAdsCompletedEvent(qqm))
       });
     } else {
       this.logger.warn('kalturaCuepoints service is not registered or entry Live');

--- a/src/ivq.tsx
+++ b/src/ivq.tsx
@@ -111,11 +111,7 @@ export class Ivq extends KalturaPlayer.core.BasePlugin {
         this._handlePlaylistConfiguration();
         this.eventManager.listen(this._player, this._player.Event.ENDED, this._handleEndEvent);
         this._disableNativePip();
-        this.eventManager.listen(this._player, this._player.Event.ALL_ADS_COMPLETED, () => {
-          const timelineService: any = this._player.getService('timeline');
-          timelineService.removeAllKalturaCuePoints()
-          this._handleTimeline(qqm); 
-        })
+        this.eventManager.listen(this._player, this._player.Event.ALL_ADS_COMPLETED, () => this._handleAdsCompletedEvent(qqm))
       });
     } else {
       this.logger.warn('kalturaCuepoints service is not registered or entry Live');
@@ -235,6 +231,16 @@ export class Ivq extends KalturaPlayer.core.BasePlugin {
       this._displayQuizSubmit();
     }
   };
+
+  private _handleAdsCompletedEvent = (qqm: QuizQuestionMap) => {
+    const timelineService: any = this._player.getService('timeline');
+    qqm.forEach((qq: QuizQuestion) => {
+      if (qq.id) {
+        timelineService.removeCueFromTimeline({ id: qq.id , startTime: qq.startTime});
+      }
+    })
+    this._handleTimeline(qqm); 
+  }
 
   private _manageIvqPopup = (onInit = true) => {
     this.logger.debug("show 'IVQ Banner'");


### PR DESCRIPTION
**Issue:**
ALL_ADS_COMPLETED event is fired for IMA and not for bumper.

**Fix:**
Listen to AD_COMPLETED instead. each ad that is finished, remove the ivq questions and apply them again.
Also when user clicked on SKIP, the behavior supposed to be the same.