### PR TITLE
fix(FEC-14599): Adjust ivq items spacing

### DIFF
--- a/src/components/ivq-overlay/ivq-overlay.scss
+++ b/src/components/ivq-overlay/ivq-overlay.scss
@@ -18,8 +18,8 @@
     overflow: hidden;
   }
   :focus {
-    outline: 1px solid var(--playkit-tab-focus-color) !important;
-    outline-offset: 2px;
+    outline: 2px solid var(--playkit-tab-focus-color) !important;
+    outline-offset: 2px !important;
     box-shadow: 0 0 0 2px #FFFFFF, 0 0 0 4px var(--playkit-tab-focus-color);
     border-radius: 4px;
   }

--- a/src/components/quiz-review/question-list-review/question-list-review.scss
+++ b/src/components/quiz-review/question-list-review/question-list-review.scss
@@ -28,6 +28,7 @@
       display: flex;
       flex-direction: column;
       width: 100%;
+      margin: 4px;
       @include outline-fix;
       .reviewAnswer {
         @include optional-answer;

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -85,6 +85,7 @@ $selection-border-width: 2px;
   height: 32px;
   align-items: center;
   padding: 5px 16px;
+  margin: 4px;
 
   background: $button-background;
   border-style: solid;


### PR DESCRIPTION
This is fixing https://kaltura.atlassian.net/browse/FEC-14599. I could not reproduce the issues reported, but I fixed the outline and spacing issues that made focus indicator get visible cut