### PR TITLE
fix(SUP-51303): IVQ questions showing twice

### DIFF
--- a/src/data-sync-manager.ts
+++ b/src/data-sync-manager.ts
@@ -20,6 +20,7 @@ export class DataSyncManager {
   public quizQuestionsMap: QuizQuestionMap = new Map();
   private _quizCuePoints: Array<any> = [];
   private _quizAnswers: Array<KalturaQuizAnswer> = [];
+  private _lastQuizCuePointStartTime: number | null = null;
 
   constructor(
     private _onQuestionsLoad: (qqm: QuizQuestionMap) => void,
@@ -361,7 +362,15 @@ export class DataSyncManager {
       return cue.endTime !== this._player.currentTime;
     });
     if (filteredQuizCues.length) {
+      //questions already showed
+      if (this._lastQuizCuePointStartTime == filteredQuizCues[0].startTime) {
+        return;
+      }
       this._onQuestionBecomeActive(filteredQuizCues[0]);
+      this._lastQuizCuePointStartTime = filteredQuizCues[0].startTime;
+    }
+    else {
+      this._lastQuizCuePointStartTime = null;
     }
   };
   private _onTimedMetadataAdded = ({payload}: TimedMetadataEvent) => {


### PR DESCRIPTION
issue:
costumer complains that questions are showing several times.

root cause:
it occured for costumer when put ivq and transcript plugins. when questions are showed there is metadata_change event, and when they are exit, there is again metada_change event with same time so questions show again as they fit to the time

solution:
add parameter that saved the last questions time and check if the time is the same as the questions should be show now.

solve [SUP-51303](https://kaltura.atlassian.net/browse/SUP-51303)

[SUP-51303]: https://kaltura.atlassian.net/browse/SUP-51303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ