### PR TITLE
fix(ADA-3351): Focus on first item of the question when answered

### DIFF
--- a/src/components/quiz-question/multi-choice/multi-choice.tsx
+++ b/src/components/quiz-question/multi-choice/multi-choice.tsx
@@ -41,9 +41,7 @@ export const MultiChoice = withText(translates)(
     const isLargePlayer = playerSize !== undefined ? playerSize >= PLAYER_BREAK_POINTS.LARGE : false;
 
     useEffect(() => {
-      if (!disabled) {
-        answersOptionsRefMap.get(0)?.focus();
-      }
+      answersOptionsRefMap.get(0)?.focus();
     }, [question]);
 
     useEffect(() => {

--- a/src/components/quiz-question/open-question/open-question.tsx
+++ b/src/components/quiz-question/open-question/open-question.tsx
@@ -59,9 +59,7 @@ export const OpenQuestion = withText(translates)(
     }
 
     useEffect(() => {
-      if (!disabled) {
-        textareaRef.current?.focus();
-      }
+      textareaRef.current?.focus();
     }, [question]);
     // Trigger debounced announcement when the answer text changes
     useEffect(() => {

--- a/src/components/quiz-question/true-false/true-false.tsx
+++ b/src/components/quiz-question/true-false/true-false.tsx
@@ -25,9 +25,7 @@ export const TrueFalse = withText(translates)(
       [onSelect]
     );
     useEffect(() => {
-      if (!disabled) {
-        answersOptionsRefMap.get(0)?.focus();
-      }
+      answersOptionsRefMap.get(0)?.focus();
     }, [question]);
 
     let answersOptionsRefMap: Map<number, HTMLElement | null> = new Map();


### PR DESCRIPTION
This fixes https://kaltura.atlassian.net/browse/ADA-3351 and it is related to https://github.com/kaltura/playkit-js-ivq/pull/201/. 
With this change, the focus moves on the first item of the question also when the question is answered now